### PR TITLE
Update API.md to reflect API changes from v. 0.96

### DIFF
--- a/api.md
+++ b/api.md
@@ -218,7 +218,7 @@ Set the specified generator (Gen1 or Gen2) to On or Off to the specified frequen
 
 _note_: in versions earlier than 0.96, the Generator and On/Off parameters were numerical:
 - (Gen1=1, Gen2=2)
-- (1=On, 0=Off)
+- (On=1, Off=0)
 
 The command then looked like:
 `HTTP PUT localhost:9401/Settings/AudioGen/1/1/1000/0`

--- a/api.md
+++ b/api.md
@@ -212,14 +212,22 @@ The above code will disable the round frequencies behavior.
 
 ## PUT /Settings/AudioGen/{Generator}/{On}/{Frequency}/{Amplitude}
 
-Set the specified generator (1 or 2) to on or off (1=on, 0=off) to the specified frequency and amplitude. For example to set Gen1 on and at a level of 0 dBV and 1 KHz, you would issue  
+Set the specified generator (Gen1 or Gen2) to On or Off to the specified frequency and amplitude. For example to set Gen1 on and at a level of 0 dBV and 1 KHz, you would issue  
 
-`HTTP PUT localhost:9401/Settings/AudioGen/1/1/1000/0`  
+`HTTP PUT localhost:9401/Settings/AudioGen/Gen1/On/1000/0`
+
+_note_: in versions earlier than 0.96, the Generator and On/Off parameters were numerical:
+- (Gen1=1, Gen2=2)
+- (1=On, 0=Off)
+
+The command then looked like:
+`HTTP PUT localhost:9401/Settings/AudioGen/1/1/1000/0`
+
 
 ### Arguments
 
-**Generator** Specifies which audio generator is being assigned. Valid values are 1 or 2  
-**On** Specifies if the generator should be 'on' (on = '1') or off (on = '0')  
+**Generator** Specifies which audio generator is being assigned. Valid values are Gen1 or Gen2  
+**On** Specifies if the generator should be on or off. Valid values are On and Off  
 **Frequency** Specifies the generator frequency, in Hz. Valid values are >= 1 Hz and <= 96000 Hz.  
 **Amplitude** Specifies the generator amplitude in dBV. Valid values are >= -120 dBV and <= 6 dBV  
 


### PR DESCRIPTION
Was playing around with the API and noticed this discrepancy. The docs are not updated to reflect the API changes for turning on a generator in release 0.96.

https://github.com/QuantAsylum/QA401H/releases/tag/0.96

> Changes to syntax of Settings/AudioGen. This was to help with log readability. In summary, you must now specify the the generator by string and on/off by string. Previously this looked like

Also
- it would probably be nice if [this guide](https://quantasylum.com/blogs/news/qa401-headless-linux) was updated with the new commands too!

- I am not sure if these changes are already reflected in the internal guide available at localhost:9401 (I am running QA401h on raspberry pi without a monitor).

Thanks for making the headless version available, except for this the setup has been running smooth this far!
